### PR TITLE
Publish new post on reasoning patterns and unpublish drafts

### DIFF
--- a/_posts/2026-03-28-authoring-quickstart.md
+++ b/_posts/2026-03-28-authoring-quickstart.md
@@ -3,6 +3,7 @@ title: Authoring quickstart
 subtitle: How to add a new post
 date: 2026-03-28
 tags: [meta, guide]
+published: false
 ---
 
 To add a new post:

--- a/_posts/2026-04-10-second-placeholder-post.md
+++ b/_posts/2026-04-10-second-placeholder-post.md
@@ -2,6 +2,7 @@
 title: A second placeholder post
 subtitle: Just here to show what a list of posts looks like
 date: 2026-04-10
+published: false
 ---
 
 This post exists purely so the home page shows more than one item in the list.

--- a/_posts/2026-04-17-hello-new-blog.md
+++ b/_posts/2026-04-17-hello-new-blog.md
@@ -3,6 +3,7 @@ title: Hello, new blog
 subtitle: A fresh start — and what to expect here
 date: 2026-04-17
 tags: [meta]
+published: false
 ---
 
 This is a placeholder post demonstrating the layout. Delete it or replace the

--- a/_posts/2026-04-17-x-failed-likely-because-y.md
+++ b/_posts/2026-04-17-x-failed-likely-because-y.md
@@ -1,0 +1,34 @@
+---
+title: "X failed, likely because Y"
+subtitle: On the language patterns that change how we reason
+date: 2026-04-17
+tags: [ai, reasoning]
+---
+
+I noticed something specific while using Gemini 2.5. Occasionally, it would output a phrase like *"X failed, likely because Y."* It caught my attention because that specific language pattern seemed to change the model's trajectory. By articulating the failure and a hypothesis, the model **reflected on its own state** and made a better decision.
+
+![A diagram of a colored neural network with interconnected nodes across three layers, representing structured patterns of thought](https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Colored_neural_network.svg/400px-Colored_neural_network.svg.png)
+
+## The Friction of Flow
+
+Most of the time, I tend to go with the flow. It's the path of least resistance. But *"going with the flow"* is often just another way of saying I'm not being rigorous. When I work that way, I'm just moving toward an output without checking the logic behind it.
+
+The mess happens when there are no checkpoints. Without a structured pattern, it's easy to skip the actual reasoning and head straight for a conclusion that might be wrong.
+
+## The Analytical Pattern
+
+There is a clear difference between a free-form thought and an **analytical pattern**. If I force myself to think through specific, dictated steps, the result changes. It's a thought experiment in adding *manual friction*:
+
+1. **Identify** the failure.
+2. **State** the likely cause.
+3. **Adjust** the next move based on that cause.
+
+Forcing these steps changes the outcome. It's not about being "smarter" in the moment. It's about using a *language scaffold* to get to a result I wouldn't have reached otherwise.
+
+## Engineering the Logic
+
+Finding these patterns is a practical exercise. In one sense, it's about making better LLM prompts. If we know certain phrases trigger better reasoning in a model, we use them. But the same logic applies to my own thinking.
+
+Reasoning isn't a vague internal process. It's often just the result of the **patterns we use to move through a problem**. If I change the pattern, I change the reasoning. It's a simple feedback loop: use better structures, get better work.
+
+In the end, it's just about finding which patterns of thought lead to the fewest errors. It's a mechanic worth untangling.

--- a/_posts/2026-04-17-x-failed-likely-because-y.md
+++ b/_posts/2026-04-17-x-failed-likely-because-y.md
@@ -5,15 +5,15 @@ date: 2026-04-17
 tags: [ai, reasoning]
 ---
 
-I noticed something specific while using Gemini 2.5. Occasionally, it would output a phrase like *"X failed, likely because Y."* It caught my attention because that specific language pattern seemed to change the model's trajectory. By articulating the failure and a hypothesis, the model **reflected on its own state** and made a better decision.
+I noticed something specific while using Gemini. Occasionally, it would output a phrase like *"X failed, likely because Y."* It caught my attention because that specific language pattern seemed to change the model's trajectory. And I suspect it was trained to do so. By articulating the failure and a hypothesis, the model **reflected on its own state** and made a better decision.
 
 ![A diagram of a colored neural network with interconnected nodes across three layers, representing structured patterns of thought](https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Colored_neural_network.svg/400px-Colored_neural_network.svg.png)
 
-## The Friction of Flow
+## The Down Side of Flow State
 
-Most of the time, I tend to go with the flow. It's the path of least resistance. But *"going with the flow"* is often just another way of saying I'm not being rigorous. When I work that way, I'm just moving toward an output without checking the logic behind it.
+A vast majority of the time, as most poeple, I tend to think on auto-pilot. It's the path of least resistance. But *"going with the flow"* is often just another way of saying I'm not being rigorous. When I work that way, I'm just moving toward an output without checking the logic behind it.
 
-The mess happens when there are no checkpoints. Without a structured pattern, it's easy to skip the actual reasoning and head straight for a conclusion that might be wrong.
+Without a structured pattern, it's easy to skip the actual reasoning and head straight for a conclusion that might be wrong.
 
 ## The Analytical Pattern
 
@@ -24,6 +24,8 @@ There is a clear difference between a free-form thought and an **analytical patt
 3. **Adjust** the next move based on that cause.
 
 Forcing these steps changes the outcome. It's not about being "smarter" in the moment. It's about using a *language scaffold* to get to a result I wouldn't have reached otherwise.
+
+I do the same in AI chats: "Tell me what is wrong with my thinking". And it works wonders for the quality of the output, plus I learn a lot more.
 
 ## Engineering the Logic
 


### PR DESCRIPTION
## Summary
This PR adds a new published post about language patterns in AI reasoning, while marking existing placeholder and guide posts as unpublished drafts.

## Key Changes
- **New post**: Added "X failed, likely because Y" exploring how specific language patterns influence reasoning in LLMs and human thinking
- **Draft status**: Marked three existing posts as unpublished:
  - `authoring-quickstart.md` (meta guide)
  - `second-placeholder-post.md` (placeholder)
  - `hello-new-blog.md` (placeholder)

## Implementation Details
The new post discusses how articulating failures and hypotheses creates a structured reasoning pattern that improves decision-making. It uses a practical three-step analytical framework (Identify → State → Adjust) to demonstrate how language scaffolding affects outcomes.

The `published: false` frontmatter flag has been added to existing posts to hide them from the public site while keeping them in the repository for reference.

https://claude.ai/code/session_01S3dnhi9TZFEy419bWvqvQo